### PR TITLE
Deploy U&E on port 8100 not 3000

### DIFF
--- a/components/ua/user-establishment-details/overlays/dev/config.yaml
+++ b/components/ua/user-establishment-details/overlays/dev/config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-establishment-details
+data:
+  PORT: "8100"


### PR DESCRIPTION
The health checks are failing on dev, meaning argocd thinks the pod is degraded and won't deploy. 