### PR TITLE
Correct UEX long name to match other repos.

### DIFF
--- a/argocd/dev/ua/user-exchange/app.yaml
+++ b/argocd/dev/ua/user-exchange/app.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       project: u-a-project
       source:
-        path: mu2/users-exchange-chart
+        path: mu2/user-exchange-chart
         repoURL: 'https://github.com/isisbusapps/merge-user-tool'
         targetRevision: develop
         helm:


### PR DESCRIPTION
Closes #44 

Consistent naming with `merge-use-tool `and `observability` repos.