### PR TITLE
Reenable and Fix NAFE probes

### DIFF
--- a/components/ua/authenticate-frontend/base/deployment.yaml
+++ b/components/ua/authenticate-frontend/base/deployment.yaml
@@ -13,30 +13,30 @@ spec:
           ports:
             - containerPort: 3000
 
-          # startupProbe:
-          #   successThreshold: 1
-          #   failureThreshold: 10
-          #   periodSeconds: 20
-          #   timeoutSeconds: 10
-          #   initialDelaySeconds: 5
-          #   httpGet:
-          #     path: /authenticate-frontend/Ready
-          #     port: 3000
-          # livenessProbe:
-          #   successThreshold: 1
-          #   failureThreshold: 5
-          #   periodSeconds: 20
-          #   timeoutSeconds: 10
-          #   httpGet:
-          #     path: /authenticate-frontend/Live
-          #     port: 3000
-          # readinessProbe:
-          #   successThreshold: 3
-          #   failureThreshold: 3
-          #   periodSeconds: 5
-          #   timeoutSeconds: 10
-          #   httpGet:
-          #     path: /authenticate-frontend/Ready
-          #     port: 3000
+          startupProbe:
+            successThreshold: 1
+            failureThreshold: 10
+            periodSeconds: 20
+            timeoutSeconds: 10
+            initialDelaySeconds: 5
+            httpGet:
+              path: /authenticate-frontend/auth/Ready
+              port: 3000
+          livenessProbe:
+            successThreshold: 1
+            failureThreshold: 5
+            periodSeconds: 20
+            timeoutSeconds: 10
+            httpGet:
+              path: /authenticate-frontend/auth/Live
+              port: 3000
+          readinessProbe:
+            successThreshold: 3
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              path: /authenticate-frontend/auth/Ready
+              port: 3000
       imagePullSecrets:
         - name: registry-creds


### PR DESCRIPTION
The NAFE startup/liveness/readiness probes were commented out when they weren't working.
I believe the issue is just that they need /auth added to the paths