### PR TITLE
Migrate prod argocd config to gitops

### DIFF
--- a/argocd/prod/ra/approved-experiments/app.yaml
+++ b/argocd/prod/ra/approved-experiments/app.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: approved-experiments
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+  - clusters:
+      selector:
+        matchLabels:
+          appEnvironment: prod
+  template:
+    metadata:
+      name: '{{.name}}-approved-experiments'
+    spec:
+      project: r-a-project
+      source:
+        path: components/ra/approved-experiments/overlays/prod
+        repoURL: 'https://github.com/isisbusapps/gitops'
+        targetRevision: main
+      destination:
+        namespace: apps
+        name: '{{.name}}'
+      syncPolicy:
+        automated: {}


### PR DESCRIPTION
Refs isisbusapps/approved-experiments#254

I moved the prod kubernetes config over in the dev migration PR, so we just need to move the argocd one.

To go in alongside:
- https://github.com/isisbusapps/approved-experiments/pull/263
- https://github.com/isisbusapps/docker-orchestration/pull/1038