### PR TITLE
Add Exp reports and reporting tool to internal redirect config

### DIFF
--- a/components/ua/authenticate-frontend/overlays/dev/internal-redirects.json
+++ b/components/ua/authenticate-frontend/overlays/dev/internal-redirects.json
@@ -37,5 +37,31 @@
         "value": "__userSession__"
       }
     ]
+  },
+  {
+    "service": "experimentalreports",
+    "extraParams": [
+      {
+        "name": "login",
+        "value": "__login__"
+      },
+      {
+        "name": "userSession",
+        "value": "__userSession__"
+      }
+    ]
+  },
+  {
+    "service": "reporting",
+    "extraParams": [
+      {
+        "name": "login",
+        "value": "__login__"
+      },
+      {
+        "name": "userSession",
+        "value": "__userSession__"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Found it while fixing the BLAAT for experimental reports https://github.com/isisbusapps/experimental-reports-view/issues/325
We think reporting tool would also need to be added, as we see same issue with redirect when we try to load the reporting tool url directly.