### PR TITLE
Update UOWS v1 service name in gateway httproute

### DIFF
--- a/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
@@ -14,12 +14,12 @@ spec:
         type: PathPrefix
         value: /users-service/v1
     backendRefs:
-    - name: user-office-web-service-v1
+    - name: user-office-web-service-rest-v1
       port: 8080
   - matches:
     - path:
         type: PathPrefix
         value: /users-service/v1/quarkus
     backendRefs:
-    - name: user-office-web-service-v1
+    - name: user-office-web-service-rest-v1
       port: 8080


### PR DESCRIPTION
Argocd is showing this route as degraded because the service name here doesn't line up with the name in https://github.com/isisbusapps/gitops/blob/df6503610b923ad93d12e28c4c1e214a3de5f41e/components/ua/users-v1/base/service.yaml