### PR TITLE
Add missing hostname bindings to U&A gateway httproutes

### DIFF
--- a/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
@@ -8,6 +8,9 @@ spec:
     kind: Gateway
     namespace: envoy-gateway-system
     sectionName: https-facilities
+  hostnames:
+  - "*.facilities.rl.ac.uk"
+  - "*.developers.facilities.rl.ac.uk"
   rules:
   - matches:
     - path:

--- a/components/ua/authenticate-frontend/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/authenticate-frontend/overlays/dev/HTTPRoute.yaml
@@ -8,6 +8,9 @@ spec:
     kind: Gateway
     namespace: envoy-gateway-system
     sectionName: https-facilities
+  hostnames:
+  - "*.facilities.rl.ac.uk"
+  - "*.developers.facilities.rl.ac.uk"
   rules:
   - matches:
     - path:

--- a/components/ua/user-establishment-details/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/user-establishment-details/overlays/dev/HTTPRoute.yaml
@@ -8,6 +8,9 @@ spec:
     kind: Gateway
     namespace: envoy-gateway-system
     sectionName: https-facilities
+  hostnames:
+  - "*.facilities.rl.ac.uk"
+  - "*.developers.facilities.rl.ac.uk"
   rules:
   - matches:
     - path:

--- a/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
@@ -8,6 +8,9 @@ spec:
     kind: Gateway
     namespace: envoy-gateway-system
     sectionName: https-facilities
+  hostnames:
+  - "*.facilities.rl.ac.uk"
+  - "*.developers.facilities.rl.ac.uk"
   rules:
   - matches:
     - path:

--- a/components/ua/users-v2/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/users-v2/overlays/dev/HTTPRoute.yaml
@@ -8,6 +8,9 @@ spec:
     kind: Gateway
     namespace: envoy-gateway-system
     sectionName: https-facilities
+  hostnames:
+  - "*.facilities.rl.ac.uk"
+  - "*.developers.facilities.rl.ac.uk"
   rules:
   - matches:
     - path:


### PR DESCRIPTION
Adding one or two of these manually via argocd seems to make the service reachable via gateway and the proxies, so I'm hopeful for this fixing dev.