### PR TITLE
Add host names to UA httproutes

### DIFF
--- a/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
@@ -2,26 +2,19 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: auth-service
+  namespace: apps
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
   hostnames:
-  - "*.facilities.rl.ac.uk"
-  - "*.developers.facilities.rl.ac.uk"
+    - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /auth-service/v0
-    backendRefs:
-    - name: auth-service
-      port: 8080
-    filters:
-      - type: URLRewrite
-        urlRewrite:
-          path:
-            type: ReplacePrefixMatch
-            replacePrefixMatch: /
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /auth-service
+      backendRefs:
+        - name: auth-service
+          port: 8080

--- a/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
@@ -18,3 +18,10 @@ spec:
       backendRefs:
         - name: auth-service
           port: 8080
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      

--- a/components/ua/authenticate-frontend/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/authenticate-frontend/overlays/dev/HTTPRoute.yaml
@@ -4,18 +4,16 @@ metadata:
   name: authenticate-frontend
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
   hostnames:
-  - "*.facilities.rl.ac.uk"
-  - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
+    - "*.developers.facilities.rl.ac.uk"
   rules:
   - matches:
     - path:
         type: PathPrefix
         value: /auth
     backendRefs:
-    - name: authenticate-frontend
-      port: 3000
+      - name: authenticate-frontend
+        port: 3000

--- a/components/ua/establishment-service/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/establishment-service/overlays/dev/HTTPRoute.yaml
@@ -2,23 +2,19 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: establishment-service
+  namespace: apps
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /establishment-service
-    backendRefs:
-    - name: establishment-service
-      port: 8080
-    filters:
-      - type: URLRewrite
-        urlRewrite:
-          path:
-            type: ReplacePrefixMatch
-            replacePrefixMatch: /
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /establishment-service
+      backendRefs:
+        - name: establishment-service
+          port: 8080

--- a/components/ua/establishment-service/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/establishment-service/overlays/dev/HTTPRoute.yaml
@@ -18,3 +18,9 @@ spec:
       backendRefs:
         - name: establishment-service
           port: 8080
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /

--- a/components/ua/mailchimp-webhooks/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/mailchimp-webhooks/overlays/dev/HTTPRoute.yaml
@@ -18,3 +18,9 @@ spec:
       backendRefs:
         - name: mailchimp-webhooks
           port: 3000
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /

--- a/components/ua/mailchimp-webhooks/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/mailchimp-webhooks/overlays/dev/HTTPRoute.yaml
@@ -2,23 +2,19 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: mailchimp-webhooks
+  namespace: apps
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /mailchimp
-    backendRefs:
-    - name: mailchimp-webhooks
-      port: 3000
-    filters:
-      - type: URLRewrite
-        urlRewrite:
-          path:
-            type: ReplacePrefixMatch
-            replacePrefixMatch: /
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /mailchimp
+      backendRefs:
+        - name: mailchimp-webhooks
+          port: 3000

--- a/components/ua/merge-user-tool/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/merge-user-tool/overlays/dev/HTTPRoute.yaml
@@ -2,17 +2,19 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: merge-user-tool
+  namespace: apps
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /users/merges
-    backendRefs:
-    - name: merge-user-tool
-      port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /users/merges
+      backendRefs:
+        - name: merge-user-tool
+          port: 8080

--- a/components/ua/messages/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/messages/overlays/dev/HTTPRoute.yaml
@@ -2,17 +2,19 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: messages-service
+  namespace: apps
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /messages
-    backendRefs:
-    - name: messages-service
-      port: 30000
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /messages
+      backendRefs:
+        - name: messages-service
+          port: 30000

--- a/components/ua/ua-dev-tools/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/ua-dev-tools/overlays/dev/HTTPRoute.yaml
@@ -2,17 +2,19 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: ua-dev-tools
+  namespace: apps
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+  hostnames:
+    - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /ua-dev-tools
-    backendRefs:
-    - name: ua-dev-tools
-      port: 8100
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /ua-dev-tools
+      backendRefs:
+        - name: ua-dev-tools
+          port: 8100

--- a/components/ua/user-establishment-details/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/user-establishment-details/overlays/dev/HTTPRoute.yaml
@@ -4,18 +4,16 @@ metadata:
   name: user-establishment-details
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
   hostnames:
-  - "*.facilities.rl.ac.uk"
-  - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
+    - "*.developers.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /UserEstablishmentDetails
-    backendRefs:
-    - name: user-establishment-details
-      port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /UserEstablishmentDetails
+      backendRefs:
+        - name: user-establishment-details
+          port: 8080

--- a/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
@@ -4,25 +4,23 @@ metadata:
   name: user-office-web-service-v1
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
   hostnames:
-  - "*.facilities.rl.ac.uk"
-  - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
+    - "*.developers.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /users-service/v1
-    backendRefs:
-    - name: user-office-web-service-rest-v1
-      port: 8080
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /users-service/v1/quarkus
-    backendRefs:
-    - name: user-office-web-service-rest-v1
-      port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /users-service/v1
+      backendRefs:
+        - name: user-office-web-service-rest-v1
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /users-service/v1/quarkus
+      backendRefs:
+        - name: user-office-web-service-rest-v1
+          port: 8080

--- a/components/ua/users-v2/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/users-v2/overlays/dev/HTTPRoute.yaml
@@ -4,24 +4,22 @@ metadata:
   name: user-office-web-service-rest-v2
 spec:
   parentRefs:
-  - name: envoy-gateway
-    kind: Gateway
-    namespace: envoy-gateway-system
-    sectionName: https-facilities
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
   hostnames:
-  - "*.facilities.rl.ac.uk"
-  - "*.developers.facilities.rl.ac.uk"
+    - "*.facilities.rl.ac.uk"
+    - "*.developers.facilities.rl.ac.uk"
   rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /users-service/v2
-    backendRefs:
-    - name: user-office-web-service-rest-v2
-      port: 8080
-    filters:
-      - type: URLRewrite
-        urlRewrite:
-          path:
-            type: ReplacePrefixMatch
-            replacePrefixMatch: /
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /users-service/v2
+      backendRefs:
+        - name: user-office-web-service-rest-v2
+          port: 8080
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /


### PR DESCRIPTION
This PR adds host names to UA httproutes.

These configs have been tested by directly visiting the Kubernetes clusters.