### PR TITLE
Add v0 to auth-service path

### DIFF
--- a/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/auth-service/overlays/dev/HTTPRoute.yaml
@@ -14,7 +14,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: /auth-service
+            value: /auth-service/v0
       backendRefs:
         - name: auth-service
           port: 8080


### PR DESCRIPTION
It was removed in #220. 

Though the application worked fine without '/v0', it failed the health checks.