### PR TITLE
Move Health Check Service to GitOps

### DIFF
--- a/argocd/dev/shared/health-check-service/app.yaml
+++ b/argocd/dev/shared/health-check-service/app.yaml
@@ -24,8 +24,8 @@ spec:
     spec:
       project: infrastructure-project
       source:
-        path: gitops/k8s/overlays/dev
-        repoURL: 'https://github.com/isisbusapps/health-check-service'
+        path: components/infra/health-check-service/overlays/dev
+        repoURL: 'https://github.com/isisbusapps/gitops'
         targetRevision: main
       destination:
         namespace: apps

--- a/components/infra/health-check-service/base/deployment.yaml
+++ b/components/infra/health-check-service/base/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: health-check-service
+spec:
+  selector:
+    matchLabels:
+      app: health-check-service
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: health-check-service
+    spec:
+      containers:
+        - name: health-check-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+      imagePullSecrets:
+        - name: registry-creds

--- a/components/infra/health-check-service/base/kustomization.yaml
+++ b/components/infra/health-check-service/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+  - deployment.yaml

--- a/components/infra/health-check-service/overlays/dev/kustomization.yaml
+++ b/components/infra/health-check-service/overlays/dev/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+  - ../../base
+configMapGenerator:
+  - name: health-check-service-servers
+    files:
+      - servers.json
+patches:
+  - path: patch-image.yaml
+  - path: patch-configmap.yaml

--- a/components/infra/health-check-service/overlays/dev/patch-configmap.yaml
+++ b/components/infra/health-check-service/overlays/dev/patch-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: health-check-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: health-check-service
+          volumeMounts:
+            - name: servers-config
+              mountPath: /config/
+              readOnly: true
+      volumes:
+        - name: servers-config
+          configMap:
+            name: health-check-service-servers
+            items:
+              - key: servers.json
+                path: servers.json

--- a/components/infra/health-check-service/overlays/dev/patch-image.yaml
+++ b/components/infra/health-check-service/overlays/dev/patch-image.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: health-check-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: health-check-service
+          image: harbor.stfc.ac.uk/isisbusapps/health-check-service@sha256:35f696db404b4609c1ae2ac282b121e7c329567d54bdac362623e19f57f71ca1
+  selector:
+    matchLabels:
+      app: health-check-service

--- a/components/infra/health-check-service/overlays/dev/servers.json
+++ b/components/infra/health-check-service/overlays/dev/servers.json
@@ -1,0 +1,88 @@
+[
+  {
+    "name": "UOWS-v1",
+    "url": "https://devapi.facilities.rl.ac.uk/users-service/v1/quarkus/health",
+    "localUrl": "http://user-office-web-service-rest-v1.apps.svc.cluster.local:8080/users-service/v1/quarkus/health"
+  },
+  {
+    "name": "UOWS-v2",
+    "url": "https://devapi.facilities.rl.ac.uk/users-service/v2/quarkus/health",
+    "localUrl": "http://user-office-web-service-rest-v2.apps.svc.cluster.local:8080/quarkus/health"
+  },
+  {
+    "name": "auth-service",
+    "url": "https://devapi.facilities.rl.ac.uk/auth-service/v0/q/health",
+    "localUrl": "http://auth-service.apps.svc.cluster.local:8080/q/health"
+  },
+  {
+    "name": "merge-user-tool",
+    "url": "https://devapi.facilities.rl.ac.uk/users/merges/uptime",
+    "localUrl": "http://merge-user-tool.apps.svc.cluster.local:8080/users/merges/uptime"
+  },
+  {
+    "name": "message",
+    "url": "https://devexternal-api.facilities.rl.ac.uk/messages",
+    "localUrl": "http://messages-service.apps.svc.cluster.local:30000/q/health"
+  },
+  {
+    "name": "mailchimp-webhooks",
+    "url": "https://devexternal-api.facilities.rl.ac.uk/mailchimp/status",
+    "localUrl": "http://mailchimp-webhooks.apps.svc.cluster.local:3000/status"
+  },
+  {
+    "name": "ua-dev-tools",
+    "url": "https://devoffice.facilities.rl.ac.uk/ua-dev-tools"
+  },
+  {
+    "name": "user-establishment-details",
+    "url": "https://devoffice.facilities.rl.ac.uk/UserEstablishmentDetails"
+  },
+  {
+    "name": "authenticate-frontend",
+    "url": "https://devoffice.facilities.rl.ac.uk/auth"
+  },
+  {
+    "name": "Visits",
+    "url": "https://devapi.facilities.rl.ac.uk/visits-service/quarkus/health"
+  },
+  {
+    "name": "schedule-service",
+    "url": "https://devapis.facilities.rl.ac.uk/ws/ScheduleWebService/health"
+  },
+  {
+    "name": "schedule-web-app",
+    "url": "https://devoffice.facilities.rl.ac.uk/schedule/HealthCheck.ashx"
+  },
+  {
+    "name": "era-web-app",
+    "url": "https://devusers.facilities.rl.ac.uk/eras/HealthCheck.ashx"
+  },
+  {
+    "name": "era-web-service",
+    "url": "https://devapis.facilities.rl.ac.uk/eraservice/HealthCheck.ashx"
+  },
+  {
+    "name": "era-reports-service",
+    "url": "https://devapis.facilities.rl.ac.uk/erareportservice/HealthCheck.ashx"
+  },
+  {
+    "name": "manage-consumables-backend",
+    "url": "https://devapis.facilities.rl.ac.uk/manage-consumables-service/api/health"
+  },
+  {
+    "name": "manage-consumables-frontend",
+    "url": "https://devoffice.facilities.rl.ac.uk/manage-consumables"
+  },
+  {
+    "name": "user-exchange-publisher",
+    "url": "https://devapi.facilities.rl.ac.uk/publisher/q/health"
+  },
+  {
+    "name": "user-exchange",
+    "url": "http://user-exchange.apps.svc.cluster.local:15692/metrics"
+  },
+  {
+    "name": "user-exchange-client-users",
+    "url": "http://user-exchange-client-users-service.apps.svc.cluster.local:8080/q/health"
+  }
+]

--- a/components/infra/health-check-service/overlays/prod/kustomization.yaml
+++ b/components/infra/health-check-service/overlays/prod/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: apps
+resources:
+  - ../../base
+configMapGenerator:
+  - name: health-check-service-servers
+    files:
+      - servers.json
+patches:
+  - path: patch-image.yaml
+  - path: patch-configmap.yaml

--- a/components/infra/health-check-service/overlays/prod/patch-configmap.yaml
+++ b/components/infra/health-check-service/overlays/prod/patch-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: health-check-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: health-check-service
+          volumeMounts:
+            - name: servers-config
+              mountPath: /config/
+              readOnly: true
+      volumes:
+        - name: servers-config
+          configMap:
+            name: health-check-service-servers
+            items:
+              - key: servers.json
+                path: servers.json

--- a/components/infra/health-check-service/overlays/prod/patch-image.yaml
+++ b/components/infra/health-check-service/overlays/prod/patch-image.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: health-check-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: health-check-service
+          image: harbor.stfc.ac.uk/isisbusapps/health-check-service@sha256:9b72ac1aedde65a610bcf4e8f2129711317e93fd8cb0cdcc2426c5b67a6a5c40
+  selector:
+    matchLabels:
+      app: health-check-service

--- a/components/infra/health-check-service/overlays/prod/servers.json
+++ b/components/infra/health-check-service/overlays/prod/servers.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "UOWS-v1",
+    "url": "https://api.facilities.rl.ac.uk/users-service/v1/quarkus/health",
+     "localUrl": "http://user-office-web-service-rest-v1.apps.svc.cluster.local:8080/users-service/v1/quarkus/health"
+  },
+  {
+    "name": "UOWS-v2",
+    "url": "https://api.facilities.rl.ac.uk/users-service/v2/quarkus/health",
+    "localUrl": "http://user-office-web-service-rest-v2.apps.svc.cluster.local:8080/quarkus/health"
+  },
+  {
+    "name": "auth-service",
+    "url": "https://api.facilities.rl.ac.uk/auth-service/v0/q/health",
+    "localUrl": "http://auth-service.apps.svc.cluster.local:8080/q/health"
+  },
+  {
+    "name": "merge-user-tool",
+    "url": "https://api.facilities.rl.ac.uk/users/merges/uptime",
+    "localUrl": "http://merge-user-tool.apps.svc.cluster.local:8080/users/merges/uptime"
+  },
+  {
+    "name": "message",
+    "url": "https://external-api.facilities.rl.ac.uk/messages",
+    "localUrl": "http://messages-service.apps.svc.cluster.local:30000/q/health"
+  },
+  {
+    "name": "mailchimp-webhooks",
+    "url": "https://external-api.facilities.rl.ac.uk/mailchimp/status",
+    "localUrl": "http://mailchimp-webhooks.apps.svc.cluster.local:3000/status"
+  },
+  {
+    "name": "ua-dev-tools",
+    "url": "https://office.facilities.rl.ac.uk/ua-dev-tools"
+  },
+  {
+    "name": "user-establishment-details",
+    "url": "https://office.facilities.rl.ac.uk/UserEstablishmentDetails"
+  },
+  {
+    "name": "schedule-service",
+    "url": "https://api.facilities.rl.ac.uk/ws/ScheduleWebService/health"
+  },
+  {
+    "name": "schedule-web-app",
+    "url": "https://office.facilities.rl.ac.uk/schedule/HealthCheck.ashx"
+  },
+  {
+    "name": "era-web-app",
+    "url": "https://users.facilities.rl.ac.uk/eras/HealthCheck.ashx"
+  },
+  {
+    "name": "era-web-service",
+    "url": "https://api.facilities.rl.ac.uk/eraservice/HealthCheck.ashx"
+  },
+  {
+    "name": "era-reports-service",
+    "url": "https://api.facilities.rl.ac.uk/erareportservice/HealthCheck.ashx"
+  },
+  {
+    "name": "manage-consumables-backend",
+    "url": "https://api.facilities.rl.ac.uk/manage-consumables-service/api/health"
+  },
+  {
+    "name": "manage-consumables-frontend",
+    "url": "https://office.facilities.rl.ac.uk/manage-consumables"
+  }
+]


### PR DESCRIPTION
Health Check Service was using a `gitops` directory in its own repo, as well as harbor.

This PR is part of moving the deployment to gitops repo, and the image to ghcr.io