### PR TITLE
Change Authenticate Frontend ULR back to devusers

### DIFF
--- a/components/infra/health-check-service/overlays/dev/servers.json
+++ b/components/infra/health-check-service/overlays/dev/servers.json
@@ -39,7 +39,7 @@
   },
   {
     "name": "authenticate-frontend",
-    "url": "https://devoffice.facilities.rl.ac.uk/auth"
+    "url": "https://devusers.facilities.rl.ac.uk/auth"
   },
   {
     "name": "Visits",


### PR DESCRIPTION
Restoring url to `devusers`. It was changed to debug this health check while firewall is having issues