### PR TITLE
Fix dev Factory deployment

### DIFF
--- a/components/shared/user-office-core-factory/base/deployment.yaml
+++ b/components/shared/user-office-core-factory/base/deployment.yaml
@@ -9,6 +9,8 @@ spec:
       app: proposal-factory
   template:
     metadata:
+      labels:
+        app: proposal-factory
       annotations:
         co.elastic.logs/processors.add_fields.target: ""
         co.elastic.logs/processors.add_fields.fields.application.name: "proposal-factory"

--- a/components/shared/user-office-core-factory/overlays/dev/deployment.yaml
+++ b/components/shared/user-office-core-factory/overlays/dev/deployment.yaml
@@ -7,6 +7,7 @@ spec:
   template:
     metadata:
       labels:
+        app: proposal-factory
         bypass-alloy-scraper: bypass
     spec:
       containers:


### PR DESCRIPTION
Argo is complaining about missing labels since I merged the factory gitops migration https://github.com/isisbusapps/gitops/pull/321 .

I've verified this fix with a dry-run:

>service/proposal-factory configured (server dry run)
deployment.apps/proposal-factory configured (server dry run)
vaultstaticsecret.secrets.hashicorp.com/proposal-db-connection-string configured (server dry run)