### PR TITLE
Migrate non-sensitive prod argocd config to gitops

### DIFF
--- a/argocd/management-prod/argocd/app.yaml
+++ b/argocd/management-prod/argocd/app.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: infrastructure-project
+  source:
+    - repoURL: 'https://github.com/isisbusapps/gitops'
+      targetRevision: main
+      path: components/infra/argocd/overlays/prod
+    - repoURL: 'https://git.developers.facilities.rl.ac.uk/isisbusapps/BisAppSettings'
+      targetRevision: master
+      path: secret-config/prod/argocd
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/components/infra/argocd/overlays/prod/argocd-ingress.yaml
+++ b/components/infra/argocd/overlays/prod/argocd-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argocd-server-ingress
+  namespace: argocd
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+      - "argocd.developers.facilities.rl.ac.uk"
+    secretName: developers-tls-certificate
+  rules:
+  - host: "argocd.developers.facilities.rl.ac.uk"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: argocd-server
+            port:
+              name: https

--- a/components/infra/argocd/overlays/prod/kustomization.yaml
+++ b/components/infra/argocd/overlays/prod/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: argocd
+
+resources:
+- ../../base
+- argocd-ingress.yaml
+
+configMapGenerator:
+  - name: argocd-cm
+    behavior: merge
+    literals:
+      - url=https://argocd.developers.facilities.rl.ac.uk


### PR DESCRIPTION
Prod equivalent of #339

Refs https://github.com/isisbusapps/gitops/issues/338

Adds the prod application file from docker-orchestration (https://github.com/isisbusapps/docker-orchestration/pull/1108), and the non-sensitive kubernetes config from bisappsettings (https://git.developers.facilities.rl.ac.uk/isisbusapps/BisAppSettings/pulls/906) that wasn't already moved as part of the base.