### PR TITLE
Deploy dev factory to fallback cluster

### DIFF
--- a/argocd/dev/shared/user-office-core-factory/app.yaml
+++ b/argocd/dev/shared/user-office-core-factory/app.yaml
@@ -12,7 +12,7 @@ spec:
         # Names of clusters to deploy the app to
         - name: dev-v3
         # Uncomment if you want to deploy to dev-microk8s-alternative
-        #- name: dev-microk8s-alternative
+        - name: dev-microk8s-alternative
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/syncPolicy

--- a/argocd/dev/shared/user-office-core-factory/app.yaml
+++ b/argocd/dev/shared/user-office-core-factory/app.yaml
@@ -7,12 +7,10 @@ spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
   generators:
-  - list:
-      elements:
-        # Names of clusters to deploy the app to
-        - name: dev-v3
-        # Uncomment if you want to deploy to dev-microk8s-alternative
-        - name: dev-microk8s-alternative
+  - clusters:
+      selector:
+        matchLabels:
+          appEnvironment: dev
   ignoreApplicationDifferences:
     - jsonPointers:
         - /spec/syncPolicy


### PR DESCRIPTION
When I moved the factory to gitops I excluded deploying it to the dev fallback cluster, so it only exists on the main dev cluster. Since the proposal backend is deployed to both, any factory requests from the fallback backend fail to reach the factory which is causing a lot of inconsistency.

If it's preferable to instead revert back to targeting clusters by environment label then let me know. 

```yaml
  generators:
  - clusters:
      selector:
        matchLabels:
          appEnvironment: dev
```