### PR TITLE
Add missing selector to factory service

### DIFF
--- a/components/shared/user-office-core-factory/base/service.yaml
+++ b/components/shared/user-office-core-factory/base/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: proposal-factory
 spec:
+  selector:
+    app: proposal-factory
   ports:
     - protocol: TCP
       port: 4500


### PR DESCRIPTION
Another fix for the intermittent dev factory problems since moving to gitops:

This selector field was missing from the service yaml, and so the service was not routing traffic to the pod. I've applied it manually to the fallback cluster to test and it's working with this fix.

It sounds like this wasn't needed before because the main dev cluster had the selector either from an older version of it or set manually at some point, and it had never been re-applied. Though I'm unsure why we didn't see problems with the fallback cluster when the factory was in docker-orchestration and deployed to both clusters.