### PR TITLE
Add SNI bypass for reverse proxy health checks

### DIFF
--- a/components/infra/gateway-api/base/gateway.yaml
+++ b/components/infra/gateway-api/base/gateway.yaml
@@ -46,3 +46,17 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+
+    # HTTPS default listener for clients without SNI (e.g. Apache mod_proxy_hcheck)
+    - name: https-default
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: developers-tls-certificate
+            namespace: apps
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/components/infra/gateway-api/base/health-probe-route.yaml
+++ b/components/infra/gateway-api/base/health-probe-route.yaml
@@ -1,0 +1,30 @@
+# Apache's mod_proxy_hcheck does not send the SNI (Server Name Indication)
+# extension during its background TLS health checks. Without SNI, Envoy
+# Gateway routes the connection to the hostname-less "https-default" listener.
+# However, HTTPRoutes that specify hostnames (e.g. *.developers.facilities.rl.ac.uk)
+# are not matched on the default listener, resulting in a 404.
+#
+# This dedicated HTTPRoute has NO hostnames and is pinned to the "https-default"
+# listener via sectionName, so it matches any Host header on non-SNI connections
+# and routes health check requests to the correct backend.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: health-probe
+  namespace: apps
+  labels:
+    app: health-probe
+spec:
+  # No hostnames — matches any Host header on the attached listener
+  parentRefs:
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+      sectionName: https-default  # Only attach to the no-SNI fallback listener
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /auth/Ready
+      backendRefs:
+        - name: authenticate-frontend
+          port: 3000

--- a/components/infra/gateway-api/base/kustomization.yaml
+++ b/components/infra/gateway-api/base/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - envoy-proxy-config.yaml
   - gateway.yaml
   - gatewayclass.yaml
+  - health-probe-route.yaml
   - https-redirect.yaml
   - reference-grant.yaml


### PR DESCRIPTION
This PR adds an SNI bypass for the reverse proxy health check. 

The health check module does not add an SNI(server name indication) to the health check request. 

Envoy expects the SNI to be present in the request. Without the SNI in the request envoy rejects the request, and the reverse proxy thinks the server is down. 

Adding a default listener and an HTTP route, and a default listener without the hostname(no SNI required, if no hostname is checked) resolves the issue