### PR TITLE
Change HTTPRoute namespace on UA Apps

### DIFF
--- a/components/ua/authenticate-frontend/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/authenticate-frontend/overlays/dev/HTTPRoute.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: authenticate-frontend
+  namespace: apps
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/components/ua/user-establishment-details/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/user-establishment-details/overlays/dev/HTTPRoute.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: user-establishment-details
+  namespace: apps
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/components/ua/user-exchange-publisher/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/user-exchange-publisher/overlays/dev/HTTPRoute.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: user-exchange-publisher
+  namespace: apps
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/components/ua/user-exchange-publisher/overlays/prod/HTTPRoute.yaml
+++ b/components/ua/user-exchange-publisher/overlays/prod/HTTPRoute.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: user-exchange-publisher
+  namespace: apps
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/users-v1/overlays/dev/HTTPRoute.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: user-office-web-service-v1
+  namespace: apps
 spec:
   parentRefs:
     - name: envoy-gateway

--- a/components/ua/users-v2/overlays/dev/HTTPRoute.yaml
+++ b/components/ua/users-v2/overlays/dev/HTTPRoute.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: user-office-web-service-rest-v2
+  namespace: apps
 spec:
   parentRefs:
     - name: envoy-gateway


### PR DESCRIPTION
Some UA apps did not have a namespace mentioned on their HTTPRoutes. This has led to connection being impossible from envoy to the UA App service.