### PR TITLE
feat: Send proposal factory logs directly to alloy collector

### DIFF
--- a/components/shared/user-office-core-factory/base/deployment.yaml
+++ b/components/shared/user-office-core-factory/base/deployment.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: proposal-factory
+        bypass-alloy-scraper: bypass
       annotations:
         co.elastic.logs/processors.add_fields.target: ""
         co.elastic.logs/processors.add_fields.fields.application.name: "proposal-factory"
@@ -24,6 +25,12 @@ spec:
           ports:
             - containerPort: 4500
           env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://alloy.alloy.svc.cluster.local:4318/v1/traces
+            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+              value: http://alloy.alloy.svc.cluster.local:4318/v1/metrics
+            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+              value: http://alloy.alloy.svc.cluster.local:4318/v1/logs
             - name: DATABASE_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:

--- a/components/shared/user-office-core-factory/overlays/dev/deployment.yaml
+++ b/components/shared/user-office-core-factory/overlays/dev/deployment.yaml
@@ -8,7 +8,6 @@ spec:
     metadata:
       labels:
         app: proposal-factory
-        bypass-alloy-scraper: bypass
     spec:
       containers:
         - name: proposal-factory
@@ -16,12 +15,6 @@ spec:
           env:
             - name: NODE_ENV
               value: development
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://alloy.alloy.svc.cluster.local:4318/v1/traces
-            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-              value: http://alloy.alloy.svc.cluster.local:4318/v1/metrics
-            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-              value: http://alloy.alloy.svc.cluster.local:4318/v1/logs
             - name: LOG_LEVEL
               value: info
             - name: BROWSER_WS_ENDPOINT

--- a/components/shared/user-office-core-factory/overlays/prod/deployment.yaml
+++ b/components/shared/user-office-core-factory/overlays/prod/deployment.yaml
@@ -15,10 +15,6 @@ spec:
           env:
             - name: NODE_ENV
               value: production
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://alloy.alloy.svc.cluster.local:4318/v1/traces
-            - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-              value: http://alloy.alloy.svc.cluster.local:4318/v1/metrics
             - name: LOG_LEVEL
               value: info
             - name: BROWSER_WS_ENDPOINT


### PR DESCRIPTION
## Summary
- Add `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` to  proposal-factory prod deployments, pointing at `http://alloy.alloy.svc.cluster.local:4318/v1/logs`, matching the existing dev configuration.
- Add the `bypass-alloy-scraper: bypass` pod label to both prod deployments so Alloy's log scraper skips these pods, preventing duplicate logs.

## Why
Dev already sends logs directly to the Alloy collector via OTLP instead of relying on pod log scraping. This brings  proposal-factory in line with that setup.
Part of: https://github.com/isisbusapps/observability/issues/150