### PR TITLE
Remove unnecessary second source from argocd definition

### DIFF
--- a/argocd/management-prod/argocd/app.yaml
+++ b/argocd/management-prod/argocd/app.yaml
@@ -8,12 +8,9 @@ metadata:
 spec:
   project: infrastructure-project
   source:
-    - repoURL: 'https://github.com/isisbusapps/gitops'
-      targetRevision: main
-      path: components/infra/argocd/overlays/prod
-    - repoURL: 'https://git.developers.facilities.rl.ac.uk/isisbusapps/BisAppSettings'
-      targetRevision: master
-      path: secret-config/prod/argocd
+    repoURL: 'https://git.developers.facilities.rl.ac.uk/isisbusapps/BisAppSettings'
+    targetRevision: master
+    path: secret-config/prod/argocd
   destination:
     namespace: argocd
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Of course I'd spot a flaw in [my PR](https://github.com/isisbusapps/gitops/pull/343) immediately after hitting the merge button.

This mirrors the source setup in the [management-dev version of this file](https://github.com/isisbusapps/gitops/blob/f40cc2a8b6bbf217ae4d515d346430b4dc004b04/argocd/management-dev/argocd/app.yaml#L10)