### PR TITLE
Update the RabbitMQ Cluster Operator ApplicationSet to generate unique ArgoCD Application names for each target cluster

### DIFF
--- a/argocd/uex/dev/shared/cert-manager/apps.yaml
+++ b/argocd/uex/dev/shared/cert-manager/apps.yaml
@@ -16,7 +16,7 @@ spec:
         #- name: dev-microk8s-alternative
   template:
     metadata:
-      name: cert-manager      
+      name: '{{.name}}-cert-manager'
     spec:
       project: infrastructure-project
       source:

--- a/argocd/uex/dev/shared/rabbitmq-operators/cluster-operator/apps.yaml
+++ b/argocd/uex/dev/shared/rabbitmq-operators/cluster-operator/apps.yaml
@@ -16,7 +16,7 @@ spec:
         #- name: dev-microk8s-alternative
   template:
     metadata:
-      name: rabbitmq-cluster-operator      
+      name: '{{.name}}-rabbitmq-cluster-operator'      
     spec:
       project: infrastructure-project
       source:

--- a/argocd/uex/dev/shared/rabbitmq-operators/topology-operator/apps.yaml
+++ b/argocd/uex/dev/shared/rabbitmq-operators/topology-operator/apps.yaml
@@ -16,7 +16,7 @@ spec:
         #- name: dev-microk8s-alternative
   template:
     metadata:
-      name: rabbitmq-topology-operator     
+      name: '{{.name}}-rabbitmq-topology-operator'     
     spec:
       project: infrastructure-project
       source:


### PR DESCRIPTION
## Change

The Application name is now generated using the cluster name:

```yaml
name: '{{.name}}-rabbitmq-cluster-operator'
```

This results in separate ArgoCD Applications for each cluster:

* `dev-v3-rabbitmq-cluster-operator`
* `dev-proxmox-rabbitmq-cluster-operator`

## Reason

The ApplicationSet deploys the RabbitMQ Cluster Operator to multiple Kubernetes clusters. Since ArgoCD Applications are managed within the same ArgoCD instance and namespace, each generated Application must have a unique name.

This change allows the operator to be deployed and managed independently on both `dev-v3` and `dev-proxmox`.
