### PR TITLE
Configure the RabbitMQ deployment to use the appropriate Kubernetes StorageClass for each target cluster

### DIFF
--- a/argocd/uex/dev/shared/message-broker/app.yaml
+++ b/argocd/uex/dev/shared/message-broker/app.yaml
@@ -9,9 +9,13 @@ spec:
   generators:
   - list:
       elements:
-        # Names of clusters to deploy the app to
+        # Cluster names and storage classes to use for rabbitmq deployment
         - name: dev-v3
+          storageClassName: csi-cinder
+
         - name: dev-proxmox
+          storageClassName: longhorn
+
         # Uncomment if you want to deploy to dev-microk8s-alternative
         #- name: dev-microk8s-alternative
   template:
@@ -29,6 +33,9 @@ spec:
           valueFiles:
             - values.yaml
             - values-httpRoute.yaml
+          parameters:
+            - name: storageClassName
+              value: '{{.storageClassName}}'
       destination:
         namespace: apps
         name: '{{.name}}'

--- a/components/shared/message-broker/rmq-message-broker-chart/templates/deployment.yaml
+++ b/components/shared/message-broker/rmq-message-broker-chart/templates/deployment.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: 1
   terminationGracePeriodSeconds: 180
   persistence:
-    storageClassName: csi-cinder
+    storageClassName: {{ $.Values.storageClassName }}
     storage: 20Gi  
   image: {{ $.Values.image }}  
   override:


### PR DESCRIPTION
- Added a cluster-specific storageClassName to the RabbitMQ ApplicationSet.
- Configured `csi-cinder` for the dev-v3 OpenStack cluster.
- Configured `longhorn` for the dev-proxmox cluster.
- Updated the RabbitMQ Helm template to use the configured storageClassName for persistent storage.

The `dev-v3` and `dev-proxmox` clusters use different storage providers. Previously, the RabbitMQ deployment was hard-coded to use csi-cinder, which caused PVC creation to fail in `dev-proxmox`.

This change allows the same RabbitMQ deployment configuration to be used across clusters while selecting the appropriate StorageClass for each environment.