### PR TITLE
Deploy UOP rabbitmq credentials to all clusters

### DIFF
--- a/argocd/uex/dev/submissions/uop-exchange-secret/app.yaml
+++ b/argocd/uex/dev/submissions/uop-exchange-secret/app.yaml
@@ -12,8 +12,7 @@ spec:
         # Names of clusters to deploy the app to
         - name: dev-v3
         - name: dev-proxmox
-        # Uncomment if you want to deploy to dev-microk8s-alternative
-        #- name: dev-microk8s-alternative
+        - name: dev-microk8s-alternative
   template:
     metadata:
       name: '{{.name}}-uop-exchange-secret'


### PR DESCRIPTION
Closes #394

https://github.com/isisbusapps/docker-orchestration/pull/1137 updated dev UOP to use a new secret for rabbitmq credentials, but it's not present on the dev microk8s cluster, and argocd/kubernetes is unable to run that config there.