### PR TITLE
Restore missing static secret in prod approved experiments

### DIFF
--- a/components/ra/approved-experiments/overlays/prod/static-secret.yaml
+++ b/components/ra/approved-experiments/overlays/prod/static-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: approved-experiments
+  namespace: apps
+spec:
+  type: kv-v2
+  refreshAfter: 30s
+  vaultAuthRef: static-auth
+
+  mount: reviews_and_allocations
+  path: prod/approved-experiments
+  destination:
+    name: approved-experiments
+    overwrite: true
+    create: true


### PR DESCRIPTION
Looks like it was accidentally moved instead of copied in #340