### PR TITLE
Add UE prod traffic policy to improve connection

### DIFF
--- a/components/ua/user-establishment-details/overlays/prod/backend-traffic-policy.yaml
+++ b/components/ua/user-establishment-details/overlays/prod/backend-traffic-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: user-establishment-details-http1
+  namespace: apps
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: user-establishment-details
+  timeout:
+    http:
+      connectionIdleTimeout: 60s
+      maxConnectionDuration: 300s
+      requestTimeout: 120s

--- a/components/ua/user-establishment-details/overlays/prod/kustomization.yaml
+++ b/components/ua/user-establishment-details/overlays/prod/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - static-secret.yaml
   - config.yaml
   - HTTPRoute.yaml
+  - backend-traffic-policy.yaml
 
 patches:
 - path: patch-image.yaml


### PR DESCRIPTION
This PR adds a backend traffic policy to increase the time limits for the RSC streaming.